### PR TITLE
gluetun control port override 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Optional:
 - `PIA_WG_CONFIG_URL` (optional: if set, download/replace `pia-wg-config` on startup)
 - `PIA_WG_CONFIG_SHA256` (optional: verify the download before installing)
 - `SELF_TEST` (optional: set to `1` to exit after startup checks)
-- 'GLUETUN_CONTROL_SERVER_PORT' (optional: to change port to look for control server)
+- `GLUETUN_CONTROL_SERVER_PORT` (optional: to change port to look for control server)
 
 ## Port forwarding
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Optional:
 - `PIA_WG_CONFIG_URL` (optional: if set, download/replace `pia-wg-config` on startup)
 - `PIA_WG_CONFIG_SHA256` (optional: verify the download before installing)
 - `SELF_TEST` (optional: set to `1` to exit after startup checks)
+- 'GLUETUN_CONTROL_SERVER_PORT' (optional: to change port to look for control server)
 
 ## Port forwarding
 

--- a/refresh-loop.sh
+++ b/refresh-loop.sh
@@ -231,7 +231,7 @@ check_connectivity() {
   fi
 
   # Use Gluetun control server API - responds instantly even when VPN is broken
-  public_ip=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:8000/v1/publicip/ip 2>/dev/null | sed -n 's/.*"public_ip":"\([^"]*\)".*/\1/p')
+  public_ip=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:${GLUETUN_CONTROL_SERVER_PORT:-8000}/v1/publicip/ip 2>/dev/null | sed -n 's/.*"public_ip":"\([^"]*\)".*/\1/p')
 
   if [ -n "$public_ip" ]; then
     log debug "VPN connected with public IP: $public_ip"
@@ -249,7 +249,7 @@ check_port_forwarding() {
     return 0  # Skip check if port forwarding not enabled
   fi
 
-  port=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:8000/v1/portforward 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p')
+  port=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:${GLUETUN_CONTROL_SERVER_PORT:-8000}/v1/portforward 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p')
 
   if [ -n "$port" ] && [ "$port" -gt 0 ]; then
     log debug "Port forwarding active on port: $port"
@@ -561,7 +561,7 @@ run_recovery_hook() {
   # Get forwarded port if port forwarding is enabled
   forwarded_port=""
   if [ "$PIA_PORT_FORWARDING" = "true" ]; then
-    forwarded_port=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:8000/v1/portforward 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p' || true)
+    forwarded_port=$(docker exec "$GLUETUN_CONTAINER" wget -qO- --timeout=5 http://localhost:${GLUETUN_CONTROL_SERVER_PORT:-8000}/v1/portforward 2>/dev/null | sed -n 's/.*"port":\([0-9]*\).*/\1/p' || true)
   fi
 
   log info "Running recovery hook (server=$server_name, port=${forwarded_port:-none})"


### PR DESCRIPTION
Ran into trouble using custom control server port and this is my proposed solution.
Thought about making it the same env name as gluetun "HTTP_CONTROL_SERVER_ADDRESS" but landed on "GLUETUN_CONTROL_SERVER_PORT" for complex env needs